### PR TITLE
Remove non-existent third parameter in `Connection:query()` calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Postgres usage example
     $Connection->connect();
 
     // ..query needed data
-    $Result = $Connection->query('select * from "pg_class"', null, false);
+    $Result = $Connection->query('select * from "pg_class"', null);
     $Data = $Result->getResult();
     var_dump($Data[0]);
 
     // ..query data with parameters
     $Result = $Connection->query('select count(*) from {{ tbl(table) }}', array(
         'table' => 'pg_class',
-    ), false);
+    ));
     $Data = $Result->getResult();
     var_dump($Data);
 

--- a/examples/postgresql.php
+++ b/examples/postgresql.php
@@ -28,13 +28,13 @@ $Connection->setUserName('postgres')
 $Connection->connect();
 
 // ..query needed data
-$Result = $Connection->query('select * from "pg_class"', null, false);
+$Result = $Connection->query('select * from "pg_class"', null);
 $Data = $Result->getResult();
 var_dump($Data[0]);
 
 // ..query data with parameters
 $Result = $Connection->query('select count(*) from {{ tbl(table) }}', array(
     'table' => 'pg_class',
-), false);
+));
 $Data = $Result->getResult();
 var_dump($Data);

--- a/source/Postgresql/Connection.php
+++ b/source/Postgresql/Connection.php
@@ -185,20 +185,20 @@ final class Connection extends DbConnection {
      * Start transaction implementation
      */
     public function begin() {
-        $this->query(self::SQL_QUERY_BEGIN, null, false);
+        $this->query(self::SQL_QUERY_BEGIN, null);
     }
 
     /**
      * Accept transaction implementation
      */
     public function commit() {
-        $this->query(self::SQL_QUERY_COMMIT, null, false);
+        $this->query(self::SQL_QUERY_COMMIT, null);
     }
 
     /**
      * Cancel transaction implementation
      */
     public function rollback() {
-        $this->query(self::SQL_QUERY_ROLLBACK, null, false);
+        $this->query(self::SQL_QUERY_ROLLBACK, null);
     }
 }


### PR DESCRIPTION
There is no third parameter in method signature:
```php
    /**
     * Complete query
     * @param string $query query string
     * @param array|null $data query parameters
     * @return QueryResult postgres query result
     */
    public function query($query, array $data = null) {}
```