### PR TITLE
Исправлена обработка исключений при парсинге ответа из Postgres

### DIFF
--- a/source/Postgresql/Connection.php
+++ b/source/Postgresql/Connection.php
@@ -179,7 +179,12 @@ final class Connection extends DbConnection {
                     case self::CODE_DUPLICATE_TYPE:
                         throw new DuplicateTypeException($errorMessage);
                     default:
-                        throw new QueryException($errorMessage . ':' . $query, $errorCode);
+                        throw new QueryException(sprintf(
+                            "%s QUERY: %s CODE: %s",
+                            $errorMessage,
+                            $query,
+                            $errorCode
+                        ));
                 }
             } else {
                 return new QueryResult($Result);

--- a/source/Postgresql/Connection.php
+++ b/source/Postgresql/Connection.php
@@ -23,6 +23,7 @@ use alxmsl\Connection\Postgresql\Exception\DuplicateEntryException;
 use alxmsl\Connection\Postgresql\Exception\DuplicateTableException;
 use alxmsl\Connection\Postgresql\Exception\DuplicateTypeException;
 use alxmsl\Connection\Postgresql\Exception\QueryException;
+use alxmsl\Connection\Postgresql\Exception\RaiseException;
 use alxmsl\Connection\Postgresql\Exception\TriesOverConnectException;
 use alxmsl\Connection\Postgresql\Exception\UndefinedTableException;
 
@@ -37,7 +38,8 @@ final class Connection extends DbConnection {
     const CODE_DUPLICATE_ENTRY = '23505',
           CODE_UNDEFINED_TABLE = '42P01',
           CODE_DUPLICATE_TABLE = '42P07',
-          CODE_DUPLICATE_TYPE  = '42710';
+          CODE_DUPLICATE_TYPE  = '42710',
+          CODE_RAISE_EXCEPTION = 'P0001';
 
     /**
      * Postgres queries
@@ -178,6 +180,8 @@ final class Connection extends DbConnection {
                         throw new DuplicateTableException($errorMessage);
                     case self::CODE_DUPLICATE_TYPE:
                         throw new DuplicateTypeException($errorMessage);
+                    case self::CODE_RAISE_EXCEPTION:
+                        throw new RaiseException($errorMessage);
                     default:
                         throw new QueryException(sprintf(
                             "%s QUERY: %s CODE: %s",

--- a/source/Postgresql/Exception/RaiseException.php
+++ b/source/Postgresql/Exception/RaiseException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace alxmsl\Connection\Postgresql\Exception;
+
+/**
+ * Postgresql raise exception
+ * @author mkrasilnikov
+ */
+final class RaiseException extends QueryException {}

--- a/tests/Postgresql/ConnectionTest.php
+++ b/tests/Postgresql/ConnectionTest.php
@@ -3,7 +3,7 @@
 namespace alxmsl\Connection\Tests\Postgresql;
 
 use alxmsl\Connection\Postgresql\Connection;
-use alxmsl\Connection\Postgresql\Exception\QueryException;
+use alxmsl\Connection\Postgresql\Exception\RaiseException;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -14,8 +14,8 @@ class ConnectionTest extends PHPUnit_Framework_TestCase {
     /**
      * Test handle query result with exception
      */
-    public function testPostgresRaiseExceptionOnFunction() {
-        $this->setExpectedException(QueryException::class);
+    public function testPostgresRaiseException() {
+        $this->setExpectedException(RaiseException::class);
         $function = '
             CREATE OR REPLACE FUNCTION raise_exception()
             RETURNS VOID AS $$

--- a/tests/Postgresql/ConnectionTest.php
+++ b/tests/Postgresql/ConnectionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace alxmsl\Connection\Tests\Postgresql;
+
+use alxmsl\Connection\Postgresql\Connection;
+use alxmsl\Connection\Postgresql\Exception\QueryException;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Test Postgres Connection
+ * @author mkrasilnikov
+ */
+class ConnectionTest extends PHPUnit_Framework_TestCase {
+    /**
+     * Test handle query result with exception
+     */
+    public function testPostgresRaiseExceptionOnFunction() {
+        $this->setExpectedException(QueryException::class);
+        $function = '
+            CREATE OR REPLACE FUNCTION raise_exception()
+            RETURNS VOID AS $$
+            BEGIN
+                RAISE EXCEPTION \'exception message;\';
+            END;
+            $$ LANGUAGE plpgsql;
+        ';
+        $Connection = new Connection();
+        $Connection->setHost('postgres');
+        $Connection->setUserName('postgres');
+        $Connection->query($function);
+        $Connection->query('SELECT raise_exception();');
+    }
+}

--- a/tests/Postgresql/QueryTemplateTest.php
+++ b/tests/Postgresql/QueryTemplateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace alxmsl\Connection\Tests;
+namespace alxmsl\Connection\Tests\Postgresql;
 
 use alxmsl\Connection\Postgresql\QueryTemplate;
 use PHPUnit_Framework_Error_Warning;


### PR DESCRIPTION
* Результат `pg_result_error_field` (возвращает строку, например `P0001`) записывается в `Exception::$code`, что вызывает фатальную ошибку:

```
PHP Fatal error:  Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in /var/www/Connection/source/Postgresql/Connection.php on line 183
```

После фикса код ошибки будет писаться в сообщение исключения `QueryException`, исключение будет выглядеть как то так 
```
alxmsl\Connection\Postgresql\Exception\QueryException: ERROR:  exception message; QUERY: SELECT raise_exception(); CODE: P0001
```

* Добавлена обработка ошибки `P0001 (raise_exception)`: 

Выкидываем исключение `alxmsl\Connection\Postgresql\Exception\RaiseException`.